### PR TITLE
added Support for the Samsung VFDM

### DIFF
--- a/tasmota/berry/include/be_gpio_defines.h
+++ b/tasmota/berry/include/be_gpio_defines.h
@@ -299,6 +299,7 @@ const be_const_member_t lv_gpio_constants[] = {
     { "TUYAMCUBR_TX", (int32_t) GPIO_TUYAMCUBR_TX },
     { "TX2X_TXD_BLACK", (int32_t) GPIO_TX2X_TXD_BLACK },
     { "TXD", (int32_t) GPIO_TXD },
+    { "VFDM_TX", (int32_t) GPIO_VFDM_TX },
     { "VINDRIKTNING_RX", (int32_t) GPIO_VINDRIKTNING_RX },
     { "VL53LXX_XSHUT1", (int32_t) GPIO_VL53LXX_XSHUT1 },
     { "WE517_RX", (int32_t) GPIO_WE517_RX },

--- a/tasmota/include/tasmota_template.h
+++ b/tasmota/include/tasmota_template.h
@@ -214,6 +214,7 @@ enum UserSelectablePins {
   GPIO_HDMI_CEC,                        // Support for HDMI CEC
   GPIO_HC8_RXD,                         // HC8 Serial interface
   GPIO_I2S_DAC,                         // Audio DAC support for ESP32 and ESP32S2
+  GPIO_VFDM_TX,						    // Serial Display Transceive Pin
   GPIO_SENSOR_END };
 
 // Error as warning to rethink GPIO usage with max 2045
@@ -475,6 +476,7 @@ const char kSensorNames[] PROGMEM =
   D_SENSOR_HDMI_CEC "|"
   D_SENSOR_HC8_RX "|"
   D_SENSOR_I2S_DAC "|"
+  D_GPIO_VFDM_TX "|"
   ;
 
 const char kSensorNamesFixed[] PROGMEM =
@@ -631,6 +633,11 @@ const uint16_t kGpioNiceList[] PROGMEM = {
   AGPIO(GPIO_SSPI_DC),                  // Software SPI Data or Command
 
 #if defined(USE_DISPLAY) || defined(USE_LVGL)
+
+#ifdef USE_DISPLAY_VFDM
+  AGPIO(GPIO_VFDM_TX),
+#endif
+
 #ifdef USE_DISPLAY_ILI9341
   AGPIO(GPIO_ILI9341_CS),
   AGPIO(GPIO_ILI9341_DC),

--- a/tasmota/language/af_AF.h
+++ b/tasmota/language/af_AF.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/bg_BG.h
+++ b/tasmota/language/bg_BG.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/tasmota/language/ca_AD.h
+++ b/tasmota/language/ca_AD.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/cs_CZ.h
+++ b/tasmota/language/cs_CZ.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/de_DE.h
+++ b/tasmota/language/de_DE.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/el_GR.h
+++ b/tasmota/language/el_GR.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/en_GB.h
+++ b/tasmota/language/en_GB.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/es_ES.h
+++ b/tasmota/language/es_ES.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fr_FR.h
+++ b/tasmota/language/fr_FR.h
@@ -942,7 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
-
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/fy_NL.h
+++ b/tasmota/language/fy_NL.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/he_HE.h
+++ b/tasmota/language/he_HE.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/hu_HU.h
+++ b/tasmota/language/hu_HU.h
@@ -945,6 +945,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/it_IT.h
+++ b/tasmota/language/it_IT.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX      "BioPDU PZEM016 - RX"
 #define D_SENSOR_BIOPDU_BIT             "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX              "LoxO2 - RX"
+#define D_GPIO_VFDM_TX         			"VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE                     "A"

--- a/tasmota/language/ko_KO.h
+++ b/tasmota/language/ko_KO.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/nl_NL.h
+++ b/tasmota/language/nl_NL.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pl_PL.h
+++ b/tasmota/language/pl_PL.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_BR.h
+++ b/tasmota/language/pt_BR.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/pt_PT.h
+++ b/tasmota/language/pt_PT.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ro_RO.h
+++ b/tasmota/language/ro_RO.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/ru_RU.h
+++ b/tasmota/language/ru_RU.h
@@ -943,6 +943,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "А"

--- a/tasmota/language/sk_SK.h
+++ b/tasmota/language/sk_SK.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/sv_SE.h
+++ b/tasmota/language/sv_SE.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/tr_TR.h
+++ b/tasmota/language/tr_TR.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/uk_UA.h
+++ b/tasmota/language/uk_UA.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE                    "А"

--- a/tasmota/language/vi_VN.h
+++ b/tasmota/language/vi_VN.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/zh_CN.h
+++ b/tasmota/language/zh_CN.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "A"

--- a/tasmota/language/zh_TW.h
+++ b/tasmota/language/zh_TW.h
@@ -942,6 +942,7 @@
 #define D_SENSOR_BIOPDU_PZEM016_RX "BioPDU PZEM016 Rx"
 #define D_SENSOR_BIOPDU_BIT    "BioPDU Bit"
 #define D_SENSOR_LOX_O2_RX     "LoxO2 RX"
+#define D_GPIO_VFDM_TX         "VFDM Tx"
 
 // Units
 #define D_UNIT_AMPERE "安培"

--- a/tasmota/tasmota_support/support_features.ino
+++ b/tasmota/tasmota_support/support_features.ino
@@ -912,7 +912,9 @@ void ResponseAppendFeatures(void)
 #ifdef USE_HC8
     feature9 |= 0x10000000;  // xsns_113_hc8.ino
 #endif
-//    feature9 |= 0x20000000;
+#if defined(USE_DISPLAY) && defined(USE_DISPLAY_VFDM)
+    feature9 |= 0x20000000;  // xdsp_33_vfdm_serial.ino
+#endif
 //    feature9 |= 0x40000000;
 //    feature9 |= 0x80000000;
   }

--- a/tasmota/tasmota_xdsp_display/xdsp_33_vfdm_serial.ino
+++ b/tasmota/tasmota_xdsp_display/xdsp_33_vfdm_serial.ino
@@ -1,0 +1,354 @@
+/*
+  xdsp_21_vfdm_serial.ino - Samsung Serial VFDM Display support for Tasmota
+
+  Copyright (C) 2023  Thomas Pantzer
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifdef USE_DISPLAY
+#ifdef USE_DISPLAY_VFDM
+
+#define XDSP_33                33
+
+#ifndef VFDM_BAUDRATE
+	#define 	VFDM_BAUDRATE		9600
+#else
+	#if (VFDM_BAUDRATE == 19200)
+		#warning "must assign txPin to hardwareSerial"
+	#else
+		#if (VFDM_BAUDRATE == 2400) || (VFDM_BAUDRATE == 4800) || (VFDM_BAUDRATE == 9600)
+		#else
+			#error "only 2400,4800,9600 and 19200 baud are supported for VFDM serial Display"
+		#endif
+	#endif
+#endif
+
+
+#define 	BYTE_TIME  			((1000000UL * (1+8+1)) / VFDM_BAUDRATE)			// in µs
+#define		INTER_COMMAND_CHARS	10		// maybe we need more
+#define		INTER_CMD_DELAY		((INTER_COMMAND_CHARS * 1000000UL * (1+8+1)) / VFDM_BAUDRATE)
+
+/*********************************************************************************************/
+//instantiate Serial Object
+TasmotaSerial *VfdmSerial = nullptr;
+
+void vfdmSend(uint8_t b)
+{
+	if (VfdmSerial == nullptr) {
+		return;
+	}
+//	VfdmSerial->flush();
+	VfdmSerial->write(b);
+}
+
+void vfdmSendBytes(uint8_t *bytes, uint8_t len)
+{
+	for (uint8_t i=0; i<len; i++) {
+		vfdmSend(bytes[i]);
+	}
+	delayMicroseconds(INTER_CMD_DELAY);
+}
+
+void VfdmClear()
+{
+	vfdmSend(0x0c);
+	delayMicroseconds(INTER_CMD_DELAY);
+}
+
+void VfdmSetCursor(uint8_t col, uint8_t row)
+{
+	uint8_t cursor[4];
+	cursor[0] = 0x1F;
+	cursor[1] = 0x24;
+	cursor[2] = col+1;
+	cursor[3] = row+1;
+	vfdmSendBytes(cursor, 4);
+}
+
+void VfdmPrint(char *line)
+{
+	vfdmSendBytes((uint8_t*)line, strlen(line));
+}
+
+
+void VfdmInitMode(void)
+{
+	uint8_t init[2];
+	init[0] = 0x1B;
+	init[1] = 0x40;
+	vfdmSendBytes(init, 2);
+	// TODO: 0x1B 0x74 <codepage>   {0..2}	 437, 850, 866
+	// TODO: 0x1B 0x52 <language>   {0..10} USA,France,Germany,UK,Denmark1,Sweden,Italy,Spain,Japan,Norway,Denmark2
+    // TODO: 0x1B 0x58 <brightness> {0..4}  0,40%,60%,80%,100%
+	VfdmClear();
+}
+
+void VfdmInit(uint8_t mode)
+{
+  switch(mode) {
+    case DISPLAY_INIT_MODE:
+      VfdmInitMode();
+#ifdef USE_DISPLAY_MODES1TO5
+      DisplayClearScreenBuffer();
+#endif  // USE_DISPLAY_MODES1TO5
+      break;
+    case DISPLAY_INIT_PARTIAL:
+    case DISPLAY_INIT_FULL:
+      break;
+  }
+}
+
+// TODO: add preinit function
+// if defined VFDM_TX => set Settings->display_model := XDSP_33
+
+
+
+void VfdmInitDriver(void)
+{
+	if (!PinUsed(GPIO_VFDM_TX)) {
+		AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("VFDM: TxPin not defined") );
+		return;
+	}
+	AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("VFDM: have pin"));
+
+	if (VfdmSerial != nullptr) {
+		AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("VFDM: driver already initialized") );
+		return;
+	}
+
+//	AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("VFDM: new serial"));
+
+	// search
+	// TODO: find some way to detect the device (or its absence)
+	int txPin = Pin(GPIO_VFDM_TX);
+	TasmotaSerial *tms = new TasmotaSerial(-1, txPin, 1);
+
+	if (tms == nullptr) {
+		AddLog(LOG_LEVEL_ERROR, PSTR("VFDM: can't allocate serial"));
+		return;
+	}
+
+//	AddLog(LOG_LEVEL_DEBUG_MORE, PSTR("VFDM: have serial 0x%08lx"), (long)tms);
+
+	if (!tms->begin(VFDM_BAUDRATE)) {   // TODO: make baudRate configurable
+		delete tms;
+		Settings->display_model = 0;
+		AddLog(LOG_LEVEL_ERROR, PSTR("VFDM: can't begin with baud %d"), VFDM_BAUDRATE);
+		return;
+	}
+
+	bool hws = tms->hardwareSerial();
+	if (hws) {
+		ClaimSerial();
+	}
+
+	VfdmSerial = tms;
+
+	if (!Settings->display_model) {
+		Settings->display_model = XDSP_33;
+	}
+
+	if (XDSP_33 == Settings->display_model) {
+		// Display is 20x2, Font is 5x7
+	    Settings->display_width = 20;
+	    Settings->display_height = 2;
+	    Settings->display_cols[0] = 20;
+	    Settings->display_cols[1] = 20;
+	    Settings->display_rows = 2;
+
+#ifdef USE_DISPLAY_MODES1TO5
+	    DisplayAllocScreenBuffer();
+#endif  // USE_DISPLAY_MODES1TO5
+
+	    VfdmInitMode();
+		AddLog(LOG_LEVEL_DEBUG, PSTR("VFDM: pin: %d, baud %d, %cw"), txPin, VFDM_BAUDRATE, hws?'h':'s');
+	    AddLog(LOG_LEVEL_INFO, PSTR("DSP: VFDM initialized"));
+	}
+}
+
+void VfdmDrawStringAt(void)
+{
+  if (dsp_flag) {  // Supply Line and Column starting with Line 1 and Column 1
+    dsp_x--;
+    dsp_y--;
+  }
+  VfdmSetCursor(dsp_x, dsp_y);
+  VfdmPrint(dsp_str);
+}
+
+void VfdmDisplayOnOff()
+{
+	uint8_t bright[4];
+	bright[0] = 0x1F;
+	bright[1] = 0x58;
+	if (disp_power) {
+		bright[2] = 4;
+	} else {
+		bright[2] = 0;
+	}
+	vfdmSendBytes(bright, 3);
+}
+
+/*********************************************************************************************/
+
+#ifdef USE_DISPLAY_MODES1TO5
+
+void VfdmCenter(uint8_t row, char* txt)
+{
+  char line[Settings->display_cols[0] +2];
+
+  int len = strlen(txt);
+  int offset = 0;
+  if (len >= Settings->display_cols[0]) {
+    len = Settings->display_cols[0];
+  } else {
+    offset = (Settings->display_cols[0] - len) / 2;
+  }
+  memset(line, 0x20, Settings->display_cols[0]);
+  line[Settings->display_cols[0]] = 0;
+  for (uint32_t i = 0; i < len; i++) {
+    line[offset +i] = txt[i];
+  }
+
+  VfdmSetCursor(0, row);
+  VfdmPrint(line);
+}
+
+bool VfdmPrintLog(void)
+{
+  bool result = false;
+
+  disp_refresh--;
+  if (!disp_refresh) {
+    disp_refresh = Settings->display_refresh;
+    if (!disp_screen_buffer_cols) { DisplayAllocScreenBuffer(); }
+
+    char* txt = DisplayLogBuffer('\337');
+    if (txt != nullptr) {
+      uint8_t last_row = Settings->display_rows -1;
+
+      for (uint32_t i = 0; i < last_row; i++) {
+        strlcpy(disp_screen_buffer[i], disp_screen_buffer[i +1], disp_screen_buffer_cols);
+        VfdmSetCursor(0, i);            // Col 0, Row i
+        VfdmPrint(disp_screen_buffer[i +1]);
+      }
+      strlcpy(disp_screen_buffer[last_row], txt, disp_screen_buffer_cols);
+      DisplayFillScreen(last_row);
+
+      AddLog(LOG_LEVEL_DEBUG, PSTR(D_LOG_DEBUG "[%s]"), disp_screen_buffer[last_row]);
+
+      VfdmSetCursor(0, last_row);
+      VfdmPrint(disp_screen_buffer[last_row]);
+
+      result = true;
+    }
+  }
+  return result;
+}
+
+void VfdmTime(void)
+{
+  char line[Settings->display_cols[0] +1];
+
+  snprintf_P(line, sizeof(line), PSTR("%02d" D_HOUR_MINUTE_SEPARATOR "%02d" D_MINUTE_SECOND_SEPARATOR "%02d"), RtcTime.hour, RtcTime.minute, RtcTime.second);
+  VfdmCenter(0, line);
+  snprintf_P(line, sizeof(line), PSTR("%02d" D_MONTH_DAY_SEPARATOR "%02d" D_YEAR_MONTH_SEPARATOR "%04d"), RtcTime.day_of_month, RtcTime.month, RtcTime.year);
+  VfdmCenter(1, line);
+}
+
+void VfdmRefresh(void)  // Every second
+{
+  if (Settings->display_mode) {  // Mode 0 is User text
+    switch (Settings->display_mode) {
+      case 1:  // Time
+        VfdmTime();
+        break;
+      case 2:  // Local
+      case 4:  // Mqtt
+        VfdmPrintLog();
+        break;
+      case 3:  // Local
+      case 5: {  // Mqtt
+        if (!VfdmPrintLog()) { VfdmTime(); }
+        break;
+      }
+    }
+  }
+}
+
+#endif  // USE_DISPLAY_MODES1TO5
+
+/*********************************************************************************************\
+ * Interface
+\*********************************************************************************************/
+
+bool Xdsp33(uint32_t function)
+{
+  bool result = false;
+
+  if (FUNC_DISPLAY_INIT_DRIVER == function) {
+    VfdmInitDriver();
+  }
+  else if (XDSP_33 == Settings->display_model) {
+    switch (function) {
+      case FUNC_DISPLAY_MODEL:
+        result = true;
+        break;
+      case FUNC_DISPLAY_INIT:
+        VfdmInit(dsp_init);
+        break;
+      case FUNC_DISPLAY_POWER:
+        VfdmDisplayOnOff();
+        break;
+      case FUNC_DISPLAY_CLEAR:
+        VfdmClear();
+        break;
+//        case FUNC_DISPLAY_DRAW_HLINE:
+//          break;
+//        case FUNC_DISPLAY_DRAW_VLINE:
+//          break;
+//        case FUNC_DISPLAY_DRAW_CIRCLE:
+//          break;
+//        case FUNC_DISPLAY_FILL_CIRCLE:
+//          break;
+//        case FUNC_DISPLAY_DRAW_RECTANGLE:
+//          break;
+//        case FUNC_DISPLAY_FILL_RECTANGLE:
+//          break;
+//        case FUNC_DISPLAY_DRAW_FRAME:
+//          break;
+//        case FUNC_DISPLAY_TEXT_SIZE:
+//          break;
+//        case FUNC_DISPLAY_FONT_SIZE:
+//          break;
+      case FUNC_DISPLAY_DRAW_STRING:
+        VfdmDrawStringAt();
+        break;
+//        case FUNC_DISPLAY_ROTATION:
+//          break;
+#ifdef USE_DISPLAY_MODES1TO5
+      case FUNC_DISPLAY_EVERY_SECOND:
+        VfdmRefresh();
+        break;
+#endif  // USE_DISPLAY_MODES1TO5
+    }
+  }
+  return result;
+}
+
+#endif  // USE_DISPLAY_VFDM
+#endif  // USE_DISPLAY
+


### PR DESCRIPTION
Support for the Samsung (V)acuum (F)luorescent (D)isplay (M)odule  20L203DA5

It is a simple 20x2 Text Display that is controlled via one single serial line and supports up to 19200 Baud.

Note that the logic level on the line needs to be inverted and amplified to 5V to make this display working. A simple transistor would do.

To enable the driver #define USE_DISPLAY_VFDM on your custom build. To override the default standard baudrate (9600)
   #define VFDM_BAUDRATE 19200  // this is the most you can get
Note that non-standard baud rates need jumper to be set on the VFDM.

A pin has to be assigned VFDM_Tx to recognize the display. There is no probing possible with a "write-only" interface. If the pin is assigned, the display is assumed to be there.

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [x] The code change is tested and works with Tasmota core ESP32 V.2.0.14
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
